### PR TITLE
Corpus for async

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "compiler-benchmark"
 version := "1.0-SNAPSHOT"
 
 def scala212 = "2.12.8"
-def dottyLatest = "0.21.0-RC1"
+def dottyLatest = "0.22.0-RC1"
 scalaVersion in ThisBuild := scala212
 val JmhConfig = config("jmh")
 

--- a/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
@@ -9,8 +9,7 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
     implicit val ctx = new ContextBase().initialCtx.fresh
     ctx.setSetting(ctx.settings.usejavacp, true)
     if (depsClasspath != null) {
-      ctx.setSetting(ctx.settings.classpath,
-                     depsClasspath.mkString(File.pathSeparator))
+      ctx.setSetting(ctx.settings.classpath, depsClasspath)
     }
     ctx.setSetting(ctx.settings.migration, false)
     ctx.setSetting(ctx.settings.outputDir, dotty.tools.io.AbstractFile.getDirectory(tempDir.getAbsolutePath))

--- a/corpus/async-legacy/latest/UseAsync.scala
+++ b/corpus/async-legacy/latest/UseAsync.scala
@@ -1,0 +1,19 @@
+import scala.concurrent._, duration.Duration, ExecutionContext.Implicits.global
+import scala.async.Async.{async, await}
+
+object Test {
+  def test: Future[Int] = async {
+    val x: Option[Either[Object, (String, String)]] = Some(Right(("a", "b")))
+    x match {
+      case Some(Left(_)) => 1
+      case Some(Right(("a", "c"))) => 2
+      case Some(Right(("a", "e"))) => 3
+      case Some(Right(("a", x))) if "ab".isEmpty => 4
+      case Some(Right(("a", "b"))) => await(f(5))
+      case Some(Right((y, x))) if x == y => 6
+      case Some(Right((_, _))) => await(f(7))
+      case None => 8
+    }
+  }
+  def f(x: Int): Future[Int] = Future.successful(x)
+}

--- a/corpus/async-legacy/latest/anf.scala
+++ b/corpus/async-legacy/latest/anf.scala
@@ -1,0 +1,463 @@
+
+package scala.async.run.anf {
+
+  import language.{reflectiveCalls, postfixOps}
+  import scala.concurrent.{Future, ExecutionContext, Await}
+  import scala.concurrent.duration._
+  import scala.async.Async.{async, await}
+  import scala.reflect.{ClassTag, classTag}
+  //import org.junit.Test
+  class Test() extends scala.annotation.StaticAnnotation
+
+  object `package` {
+
+    implicit class FutureOps[T](f: Future[T]) {
+      def block: T = Await.result(f, Duration.Inf)
+    }
+    // scala.tools.partest.TestUtil.intercept is not good enough for us
+    def intercept[T <: Throwable : ClassTag](body: => Any): T = {
+      try {
+        body
+        throw new Exception(s"Exception of type ${classTag[T]} was not thrown")
+      } catch {
+        case t: Throwable =>
+          if (!classTag[T].runtimeClass.isAssignableFrom(t.getClass)) throw t
+          else t.asInstanceOf[T]
+      }
+    }
+    implicit class objectops(obj: Any) {
+      def mustBe(other: Any) = assert(obj == other, obj + " is not " + other)
+
+      def mustEqual(other: Any) = mustBe(other)
+    }
+
+  }
+  import Future.{successful => fut}
+
+  import ExecutionContext.Implicits.global
+
+  class AnfTestClass {
+
+    def base(x: Int): Future[Int] = Future {
+      x + 2
+    }
+
+    def m(y: Int): Future[Int] = async {
+      val blerg = base(y)
+      await(blerg)
+    }
+
+    def m2(y: Int): Future[Int] = async {
+      val f = base(y)
+      val f2 = base(y + 1)
+      await(f) + await(f2)
+    }
+
+    def m3(y: Int): Future[Int] = async {
+      val f = base(y)
+      var z = 0
+      if (y > 0) {
+        z = await(f) + 2
+      } else {
+        z = await(f) - 2
+      }
+      z
+    }
+
+    def m4(y: Int): Future[Int] = async {
+      val f = base(y)
+      val z = if (y > 0) {
+        await(f) + 2
+      } else {
+        await(f) - 2
+      }
+      z + 1
+    }
+
+    def futureUnitIfElse(y: Int): Future[Unit] = async {
+      val f = base(y)
+      if (y > 0) {
+        State.result = await(f) + 2
+      } else {
+        State.result = await(f) - 2
+      }
+    }
+  }
+
+  object State {
+    @volatile var result: Int = 0
+  }
+
+  class AnfTransformSpec {
+
+    @Test
+    def `simple ANF transform`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.m(10)
+      val res = Await.result(fut, 2 seconds)
+      res mustBe (12)
+    }
+
+    @Test
+    def `simple ANF transform 2`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.m2(10)
+      val res = Await.result(fut, 2 seconds)
+      res mustBe (25)
+    }
+
+    @Test
+    def `simple ANF transform 3`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.m3(10)
+      val res = Await.result(fut, 2 seconds)
+      res mustBe (14)
+    }
+
+    @Test
+    def `ANF transform of assigning the result of an if-else`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.m4(10)
+      val res = Await.result(fut, 2 seconds)
+      res mustBe (15)
+    }
+
+    @Test
+    def `Unit-typed if-else in tail position`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.futureUnitIfElse(10)
+      Await.result(fut, 2 seconds)
+      State.result mustBe (14)
+    }
+
+    @Test
+    def `inlining block does not produce duplicate definition`(): Unit = {
+      async {
+        val f = 12
+        val x = await(fut(f))
+
+        {
+          type X = Int
+          val x: X = 42
+          identity(x)
+        }
+        type X = Int
+        x: X
+      }.block
+    }
+
+    @Test
+    def `inlining block in tail position does not produce duplicate definition`(): Unit = {
+      async {
+        val f = 12
+        val x = await(fut(f))
+
+        {
+          val x = 42
+          x
+        }
+      }.block mustBe (42)
+    }
+
+    @Test
+    def `match as expression 1`(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        val x = "" match {
+          case _ => await(fut(1)) + 1
+        }
+        x
+      }
+      result.block mustBe (2)
+    }
+
+    @Test
+    def `match as expression 2`(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        val x = "" match {
+          case "" if false => await(fut(1)) + 1
+          case _           => 2 + await(fut(1))
+        }
+        val y = x
+        "" match {
+          case _ => await(fut(y)) + 100
+        }
+      }
+      result.block mustBe (103)
+    }
+
+    @Test
+    def nestedAwaitAsBareExpression(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        await(fut(await(fut("")).isEmpty))
+      }
+      result.block mustBe (true)
+    }
+
+    @Test
+    def nestedAwaitInBlock(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        ()
+        await(fut(await(fut("")).isEmpty))
+      }
+      result.block mustBe (true)
+    }
+
+    @Test
+    def nestedAwaitInIf(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        if ("".isEmpty)
+          await(fut(await(fut("")).isEmpty))
+        else 0
+      }
+      result.block mustBe (true)
+    }
+
+    @Test
+    def byNameExpressionsArentLifted(): Unit = {
+      def foo(ignored: => Any, b: Int) = b
+      val result = async {
+        foo(???, await(fut(1)))
+      }
+      result.block mustBe (1)
+    }
+
+    @Test
+    def evaluationOrderRespected(): Unit = {
+      def foo(a: Int, b: Int) = (a, b)
+      val result = async {
+        var i = 0
+        def next() = {
+          i += 1
+          i
+        }
+        foo(next(), await(fut(next())))
+      }
+      result.block mustBe ((1, 2))
+    }
+
+    @Test
+    def awaitInNonPrimaryParamSection1(): Unit = {
+      def foo(a0: Int)(b0: Int) = s"a0 = $a0, b0 = $b0"
+      val res = async {
+        var i = 0
+        def get = {i += 1; i}
+        foo(get)(await(fut(get)))
+      }
+      res.block mustBe "a0 = 1, b0 = 2"
+    }
+
+    @Test
+    def awaitInNonPrimaryParamSection2(): Unit = {
+      def foo[T](a0: Int)(b0: Int*) = s"a0 = $a0, b0 = ${b0.head}"
+      val res = async {
+        var i = 0
+        def get = async{i += 1; i}
+        foo[Int](await(get))(await(get) :: await(async(Nil)) : _*)
+      }
+      res.block mustBe "a0 = 1, b0 = 2"
+    }
+
+    @Test
+    def awaitInNonPrimaryParamSectionWithLazy1(): Unit = {
+      def foo[T](a: => Int)(b: Int) = b
+      val res = async {
+        def get = async {0}
+        foo[Int](???)(await(get))
+      }
+      res.block mustBe 0
+    }
+
+    @Test
+    def awaitInNonPrimaryParamSectionWithLazy2(): Unit = {
+      def foo[T](a: Int)(b: => Int) = a
+      val res = async {
+        def get = async {0}
+        foo[Int](await(get))(???)
+      }
+      res.block mustBe 0
+    }
+
+    @Test
+    def awaitWithLazy(): Unit = {
+      def foo[T](a: Int, b: => Int) = a
+      val res = async {
+        def get = async {0}
+        foo[Int](await(get), ???)
+      }
+      res.block mustBe 0
+    }
+
+    @Test
+    def awaitOkInReciever(): Unit = {
+      class Foo { def bar(a: Int)(b: Int) = a + b }
+      async {
+        await(async(new Foo)).bar(1)(2)
+      }
+    }
+
+    @Test
+    def namedArgumentsRespectEvaluationOrder(): Unit = {
+      def foo(a: Int, b: Int) = (a, b)
+      val result = async {
+        var i = 0
+        def next() = {
+          i += 1
+          i
+        }
+        foo(b = next(), a = await(fut(next())))
+      }
+      result.block mustBe ((2, 1))
+    }
+
+    @Test
+    def namedAndDefaultArgumentsRespectEvaluationOrder(): Unit = {
+      var i = 0
+      def next() = {
+        i += 1
+        i
+      }
+      def foo(a: Int = next(), b: Int = next()) = (a, b)
+      async {
+        foo(b = await(fut(next())))
+      }.block mustBe ((2, 1))
+      i = 0
+      async {
+        foo(a = await(fut(next())))
+      }.block mustBe ((1, 2))
+    }
+
+    @Test
+    def repeatedParams1(): Unit = {
+      var i = 0
+      def foo(a: Int, b: Int*) = b.toList
+      def id(i: Int) = i
+      async {
+        foo(await(fut(0)), id(1), id(2), id(3), await(fut(4)))
+      }.block mustBe (List(1, 2, 3, 4))
+    }
+
+    @Test
+    def repeatedParams2(): Unit = {
+      var i = 0
+      def foo(a: Int, b: Int*) = b.toList
+      def id(i: Int) = i
+      async {
+        foo(await(fut(0)), List(id(1), id(2), id(3)): _*)
+      }.block mustBe (List(1, 2, 3))
+    }
+
+    @Test
+    def awaitInThrow(): Unit = {
+      intercept[Exception](
+        async {
+          throw new Exception("msg: " + await(fut(0)))
+        }.block
+      ).getMessage mustBe "msg: 0"
+    }
+
+    @Test
+    def awaitInTyped(): Unit = {
+      async {
+        (("msg: " + await(fut(0))): String).toString
+      }.block mustBe "msg: 0"
+    }
+
+
+    @Test
+    def awaitInAssign(): Unit = {
+      async {
+        var x = 0
+        x = await(fut(1))
+        x
+      }.block mustBe 1
+    }
+
+    @Test
+    def caseBodyMustBeTypedAsUnit(): Unit = {
+      val Up = 1
+      val Down = 2
+      val sign = async {
+        await(fut(1)) match {
+          case Up   => 1.0
+          case Down => -1.0
+        }
+      }
+      sign.block mustBe 1.0
+    }
+
+//    @Test
+//    def awaitInImplicitApply(): Unit = {
+//      val tb = mkToolbox(s"-cp ${toolboxClasspath}")
+//      val tree = tb.typeCheck(tb.parse {
+//        """
+//          | import language.implicitConversions
+//          | import _root_.scala.async.Async.{async, await}
+//          | import _root_.scala.concurrent._
+//          | import ExecutionContext.Implicits.global
+//          | implicit def view(a: Int): String = ""
+//          | async {
+//          |   await(0).length
+//          | }
+//        """.stripMargin
+//      })
+//      val applyImplicitView = tree.collect { case x if x.getClass.getName.endsWith("ApplyImplicitView") => x }
+//      println(applyImplicitView)
+//      applyImplicitView.map(_.toString) mustStartWith List("view(")
+//    }
+
+    @Test
+    def nothingTypedIf(): Unit = {
+      val result = util.Try(async {
+        if (true) {
+          val n = await(fut(1))
+          if (n < 2) {
+            throw new RuntimeException("case a")
+          }
+          else {
+            throw new RuntimeException("case b")
+          }
+        }
+        else {
+          "case c"
+        }
+      }.block)
+
+      assert(result.asInstanceOf[util.Failure[_]].exception.getMessage == "case a")
+    }
+
+    @Test
+    def awaitInArrayValue(): Unit = {
+      val result = async {
+        Array(1, await(fut(2)), await(fut(3))).sum
+      }.block
+
+      result mustBe 6
+    }
+
+    @Test
+    def nothingTypedMatch(): Unit = {
+      val result = util.Try(async {
+        0 match {
+          case _ if "".isEmpty =>
+            val n = await(fut(1))
+            n match {
+              case _ if n < 2 =>
+                throw new RuntimeException("case a")
+              case _ =>
+                throw new RuntimeException("case b")
+            }
+          case _ =>
+            "case c"
+        }
+      }.block)
+
+      assert(result.asInstanceOf[util.Failure[_]].exception.getMessage == "case a")
+    }
+  }
+
+}

--- a/corpus/async-legacy/latest/deps.txt
+++ b/corpus/async-legacy/latest/deps.txt
@@ -1,0 +1,1 @@
+https://repo1.maven.org/maven2/org/scala-lang/modules/scala-async_2.12/0.10.0/scala-async_2.12-0.10.0.jar

--- a/corpus/async/latest/UseAsync.scala
+++ b/corpus/async/latest/UseAsync.scala
@@ -1,0 +1,19 @@
+import scala.concurrent._, duration.Duration, ExecutionContext.Implicits.global
+import scala.async.Async.{async, await}
+
+object Test {
+  def test: Future[Int] = async {
+    val x: Option[Either[Object, (String, String)]] = Some(Right(("a", "b")))
+    x match {
+      case Some(Left(_)) => 1
+      case Some(Right(("a", "c"))) => 2
+      case Some(Right(("a", "e"))) => 3
+      case Some(Right(("a", x))) if "ab".isEmpty => 4
+      case Some(Right(("a", "b"))) => await(f(5))
+      case Some(Right((y, x))) if x == y => 6
+      case Some(Right((_, _))) => await(f(7))
+      case None => 8
+    }
+  }
+  def f(x: Int): Future[Int] = Future.successful(x)
+}

--- a/corpus/async/latest/anf.scala
+++ b/corpus/async/latest/anf.scala
@@ -1,0 +1,463 @@
+
+package scala.async.run.anf {
+
+  import language.{reflectiveCalls, postfixOps}
+  import scala.concurrent.{Future, ExecutionContext, Await}
+  import scala.concurrent.duration._
+  import scala.async.Async.{async, await}
+  import scala.reflect.{ClassTag, classTag}
+  //import org.junit.Test
+  class Test() extends scala.annotation.StaticAnnotation
+
+  object `package` {
+
+    implicit class FutureOps[T](f: Future[T]) {
+      def block: T = Await.result(f, Duration.Inf)
+    }
+    // scala.tools.partest.TestUtil.intercept is not good enough for us
+    def intercept[T <: Throwable : ClassTag](body: => Any): T = {
+      try {
+        body
+        throw new Exception(s"Exception of type ${classTag[T]} was not thrown")
+      } catch {
+        case t: Throwable =>
+          if (!classTag[T].runtimeClass.isAssignableFrom(t.getClass)) throw t
+          else t.asInstanceOf[T]
+      }
+    }
+    implicit class objectops(obj: Any) {
+      def mustBe(other: Any) = assert(obj == other, obj + " is not " + other)
+
+      def mustEqual(other: Any) = mustBe(other)
+    }
+
+  }
+  import Future.{successful => fut}
+
+  import ExecutionContext.Implicits.global
+
+  class AnfTestClass {
+
+    def base(x: Int): Future[Int] = Future {
+      x + 2
+    }
+
+    def m(y: Int): Future[Int] = async {
+      val blerg = base(y)
+      await(blerg)
+    }
+
+    def m2(y: Int): Future[Int] = async {
+      val f = base(y)
+      val f2 = base(y + 1)
+      await(f) + await(f2)
+    }
+
+    def m3(y: Int): Future[Int] = async {
+      val f = base(y)
+      var z = 0
+      if (y > 0) {
+        z = await(f) + 2
+      } else {
+        z = await(f) - 2
+      }
+      z
+    }
+
+    def m4(y: Int): Future[Int] = async {
+      val f = base(y)
+      val z = if (y > 0) {
+        await(f) + 2
+      } else {
+        await(f) - 2
+      }
+      z + 1
+    }
+
+    def futureUnitIfElse(y: Int): Future[Unit] = async {
+      val f = base(y)
+      if (y > 0) {
+        State.result = await(f) + 2
+      } else {
+        State.result = await(f) - 2
+      }
+    }
+  }
+
+  object State {
+    @volatile var result: Int = 0
+  }
+
+  class AnfTransformSpec {
+
+    @Test
+    def `simple ANF transform`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.m(10)
+      val res = Await.result(fut, 2 seconds)
+      res mustBe (12)
+    }
+
+    @Test
+    def `simple ANF transform 2`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.m2(10)
+      val res = Await.result(fut, 2 seconds)
+      res mustBe (25)
+    }
+
+    @Test
+    def `simple ANF transform 3`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.m3(10)
+      val res = Await.result(fut, 2 seconds)
+      res mustBe (14)
+    }
+
+    @Test
+    def `ANF transform of assigning the result of an if-else`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.m4(10)
+      val res = Await.result(fut, 2 seconds)
+      res mustBe (15)
+    }
+
+    @Test
+    def `Unit-typed if-else in tail position`(): Unit = {
+      val o = new AnfTestClass
+      val fut = o.futureUnitIfElse(10)
+      Await.result(fut, 2 seconds)
+      State.result mustBe (14)
+    }
+
+    @Test
+    def `inlining block does not produce duplicate definition`(): Unit = {
+      async {
+        val f = 12
+        val x = await(fut(f))
+
+        {
+          type X = Int
+          val x: X = 42
+          identity(x)
+        }
+        type X = Int
+        x: X
+      }.block
+    }
+
+    @Test
+    def `inlining block in tail position does not produce duplicate definition`(): Unit = {
+      async {
+        val f = 12
+        val x = await(fut(f))
+
+        {
+          val x = 42
+          x
+        }
+      }.block mustBe (42)
+    }
+
+    @Test
+    def `match as expression 1`(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        val x = "" match {
+          case _ => await(fut(1)) + 1
+        }
+        x
+      }
+      result.block mustBe (2)
+    }
+
+    @Test
+    def `match as expression 2`(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        val x = "" match {
+          case "" if false => await(fut(1)) + 1
+          case _           => 2 + await(fut(1))
+        }
+        val y = x
+        "" match {
+          case _ => await(fut(y)) + 100
+        }
+      }
+      result.block mustBe (103)
+    }
+
+    @Test
+    def nestedAwaitAsBareExpression(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        await(fut(await(fut("")).isEmpty))
+      }
+      result.block mustBe (true)
+    }
+
+    @Test
+    def nestedAwaitInBlock(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        ()
+        await(fut(await(fut("")).isEmpty))
+      }
+      result.block mustBe (true)
+    }
+
+    @Test
+    def nestedAwaitInIf(): Unit = {
+      import ExecutionContext.Implicits.global
+      val result = async {
+        if ("".isEmpty)
+          await(fut(await(fut("")).isEmpty))
+        else 0
+      }
+      result.block mustBe (true)
+    }
+
+    @Test
+    def byNameExpressionsArentLifted(): Unit = {
+      def foo(ignored: => Any, b: Int) = b
+      val result = async {
+        foo(???, await(fut(1)))
+      }
+      result.block mustBe (1)
+    }
+
+    @Test
+    def evaluationOrderRespected(): Unit = {
+      def foo(a: Int, b: Int) = (a, b)
+      val result = async {
+        var i = 0
+        def next() = {
+          i += 1
+          i
+        }
+        foo(next(), await(fut(next())))
+      }
+      result.block mustBe ((1, 2))
+    }
+
+    @Test
+    def awaitInNonPrimaryParamSection1(): Unit = {
+      def foo(a0: Int)(b0: Int) = s"a0 = $a0, b0 = $b0"
+      val res = async {
+        var i = 0
+        def get = {i += 1; i}
+        foo(get)(await(fut(get)))
+      }
+      res.block mustBe "a0 = 1, b0 = 2"
+    }
+
+    @Test
+    def awaitInNonPrimaryParamSection2(): Unit = {
+      def foo[T](a0: Int)(b0: Int*) = s"a0 = $a0, b0 = ${b0.head}"
+      val res = async {
+        var i = 0
+        def get = async{i += 1; i}
+        foo[Int](await(get))(await(get) :: await(async(Nil)) : _*)
+      }
+      res.block mustBe "a0 = 1, b0 = 2"
+    }
+
+    @Test
+    def awaitInNonPrimaryParamSectionWithLazy1(): Unit = {
+      def foo[T](a: => Int)(b: Int) = b
+      val res = async {
+        def get = async {0}
+        foo[Int](???)(await(get))
+      }
+      res.block mustBe 0
+    }
+
+    @Test
+    def awaitInNonPrimaryParamSectionWithLazy2(): Unit = {
+      def foo[T](a: Int)(b: => Int) = a
+      val res = async {
+        def get = async {0}
+        foo[Int](await(get))(???)
+      }
+      res.block mustBe 0
+    }
+
+    @Test
+    def awaitWithLazy(): Unit = {
+      def foo[T](a: Int, b: => Int) = a
+      val res = async {
+        def get = async {0}
+        foo[Int](await(get), ???)
+      }
+      res.block mustBe 0
+    }
+
+    @Test
+    def awaitOkInReciever(): Unit = {
+      class Foo { def bar(a: Int)(b: Int) = a + b }
+      async {
+        await(async(new Foo)).bar(1)(2)
+      }
+    }
+
+    @Test
+    def namedArgumentsRespectEvaluationOrder(): Unit = {
+      def foo(a: Int, b: Int) = (a, b)
+      val result = async {
+        var i = 0
+        def next() = {
+          i += 1
+          i
+        }
+        foo(b = next(), a = await(fut(next())))
+      }
+      result.block mustBe ((2, 1))
+    }
+
+    @Test
+    def namedAndDefaultArgumentsRespectEvaluationOrder(): Unit = {
+      var i = 0
+      def next() = {
+        i += 1
+        i
+      }
+      def foo(a: Int = next(), b: Int = next()) = (a, b)
+      async {
+        foo(b = await(fut(next())))
+      }.block mustBe ((2, 1))
+      i = 0
+      async {
+        foo(a = await(fut(next())))
+      }.block mustBe ((1, 2))
+    }
+
+    @Test
+    def repeatedParams1(): Unit = {
+      var i = 0
+      def foo(a: Int, b: Int*) = b.toList
+      def id(i: Int) = i
+      async {
+        foo(await(fut(0)), id(1), id(2), id(3), await(fut(4)))
+      }.block mustBe (List(1, 2, 3, 4))
+    }
+
+    @Test
+    def repeatedParams2(): Unit = {
+      var i = 0
+      def foo(a: Int, b: Int*) = b.toList
+      def id(i: Int) = i
+      async {
+        foo(await(fut(0)), List(id(1), id(2), id(3)): _*)
+      }.block mustBe (List(1, 2, 3))
+    }
+
+    @Test
+    def awaitInThrow(): Unit = {
+      intercept[Exception](
+        async {
+          throw new Exception("msg: " + await(fut(0)))
+        }.block
+      ).getMessage mustBe "msg: 0"
+    }
+
+    @Test
+    def awaitInTyped(): Unit = {
+      async {
+        (("msg: " + await(fut(0))): String).toString
+      }.block mustBe "msg: 0"
+    }
+
+
+    @Test
+    def awaitInAssign(): Unit = {
+      async {
+        var x = 0
+        x = await(fut(1))
+        x
+      }.block mustBe 1
+    }
+
+    @Test
+    def caseBodyMustBeTypedAsUnit(): Unit = {
+      val Up = 1
+      val Down = 2
+      val sign = async {
+        await(fut(1)) match {
+          case Up   => 1.0
+          case Down => -1.0
+        }
+      }
+      sign.block mustBe 1.0
+    }
+
+//    @Test
+//    def awaitInImplicitApply(): Unit = {
+//      val tb = mkToolbox(s"-cp ${toolboxClasspath}")
+//      val tree = tb.typeCheck(tb.parse {
+//        """
+//          | import language.implicitConversions
+//          | import _root_.scala.async.Async.{async, await}
+//          | import _root_.scala.concurrent._
+//          | import ExecutionContext.Implicits.global
+//          | implicit def view(a: Int): String = ""
+//          | async {
+//          |   await(0).length
+//          | }
+//        """.stripMargin
+//      })
+//      val applyImplicitView = tree.collect { case x if x.getClass.getName.endsWith("ApplyImplicitView") => x }
+//      println(applyImplicitView)
+//      applyImplicitView.map(_.toString) mustStartWith List("view(")
+//    }
+
+    @Test
+    def nothingTypedIf(): Unit = {
+      val result = util.Try(async {
+        if (true) {
+          val n = await(fut(1))
+          if (n < 2) {
+            throw new RuntimeException("case a")
+          }
+          else {
+            throw new RuntimeException("case b")
+          }
+        }
+        else {
+          "case c"
+        }
+      }.block)
+
+      assert(result.asInstanceOf[util.Failure[_]].exception.getMessage == "case a")
+    }
+
+    @Test
+    def awaitInArrayValue(): Unit = {
+      val result = async {
+        Array(1, await(fut(2)), await(fut(3))).sum
+      }.block
+
+      result mustBe 6
+    }
+
+    @Test
+    def nothingTypedMatch(): Unit = {
+      val result = util.Try(async {
+        0 match {
+          case _ if "".isEmpty =>
+            val n = await(fut(1))
+            n match {
+              case _ if n < 2 =>
+                throw new RuntimeException("case a")
+              case _ =>
+                throw new RuntimeException("case b")
+            }
+          case _ =>
+            "case c"
+        }
+      }.block)
+
+      assert(result.asInstanceOf[util.Failure[_]].exception.getMessage == "case a")
+    }
+  }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 
 // sbt-dotty plugin - to support `scalaVersion := "0.x"`
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.4")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.0")


### PR DESCRIPTION
Comparing the status quo (scala-async macro) to the [forthcoming](https://github.com/retronym/scala/pull/88) compiler-integrated, post-erasure version.

We expect the new version to be faster to compile because:
  - It runs later in the compiler chain (after erasure), so it deals with simpler trees and the heft of the trees it creates is seen be fewer subsequent phases
  - It now generates [far fewer states](https://gist.github.com/retronym/50839a051db9b6d1fcd0719d99ecbfc2) when `await` are inside if/else or patterns. 
    - This can have a run-on benefit of needing to lift fewer locals into fields
  - It uses compiler internal APIs for tranformers that avoids some overhead of the `scala.reflect.api` layer
  - Much of the implementation has been reworked to reduce allocations (ie using `ListBuffer`s judiciously rather than temporary lists)
  - Some inefficiencies in compiler infrastructure have been remedied (tree attachments, typing transformers)

The results look good:

Compile time: 0.365x
Allocations 0.67x


Take these with a pinch of salt at the benchmark corpus is designed to stress async. Real applications containing relatively fewer async blocks would see smaller improvements in compile time.

```
Benchmark                                                    (corpusPath)  (corpusVersion)  (extraArgs)  (resident)  (scalaVersion)      (source)    Mode  Cnt         Score          Error     Units
HotScalacBenchmark.compile                                      ../corpus           latest                    false         2.12.10  async-legacy  sample  131       468.485 ±       11.269     ms/op
HotScalacBenchmark.compile:compile·p0.00                        ../corpus           latest                    false         2.12.10  async-legacy  sample            403.702                    ms/op
HotScalacBenchmark.compile:compile·p0.50                        ../corpus           latest                    false         2.12.10  async-legacy  sample            459.276                    ms/op
HotScalacBenchmark.compile:compile·p0.90                        ../corpus           latest                    false         2.12.10  async-legacy  sample            508.979                    ms/op
HotScalacBenchmark.compile:compile·p0.95                        ../corpus           latest                    false         2.12.10  async-legacy  sample            534.564                    ms/op
HotScalacBenchmark.compile:compile·p0.99                        ../corpus           latest                    false         2.12.10  async-legacy  sample            669.956                    ms/op
HotScalacBenchmark.compile:compile·p0.999                       ../corpus           latest                    false         2.12.10  async-legacy  sample            684.720                    ms/op
HotScalacBenchmark.compile:compile·p0.9999                      ../corpus           latest                    false         2.12.10  async-legacy  sample            684.720                    ms/op
HotScalacBenchmark.compile:compile·p1.00                        ../corpus           latest                    false         2.12.10  async-legacy  sample            684.720                    ms/op
HotScalacBenchmark.compile:·compiler.nmethodCodeSize            ../corpus           latest                    false         2.12.10  async-legacy  sample    6    126011.531                       Kb
HotScalacBenchmark.compile:·compiler.nmethodSize                ../corpus           latest                    false         2.12.10  async-legacy  sample    6    251547.297                       Kb
HotScalacBenchmark.compile:·compiler.osrBytes                   ../corpus           latest                    false         2.12.10  async-legacy  sample    6        21.299                       Kb
HotScalacBenchmark.compile:·compiler.osrCompiles                ../corpus           latest                    false         2.12.10  async-legacy  sample    6        54.000                  methods
HotScalacBenchmark.compile:·compiler.osrTime                    ../corpus           latest                    false         2.12.10  async-legacy  sample    6       348.016                       ms
HotScalacBenchmark.compile:·compiler.standardBytes              ../corpus           latest                    false         2.12.10  async-legacy  sample    6     10203.511                       Kb
HotScalacBenchmark.compile:·compiler.standardCompiles           ../corpus           latest                    false         2.12.10  async-legacy  sample    6     50396.000                  methods
HotScalacBenchmark.compile:·compiler.standardTime               ../corpus           latest                    false         2.12.10  async-legacy  sample    6    122174.371                       ms
HotScalacBenchmark.compile:·compiler.totalBailouts              ../corpus           latest                    false         2.12.10  async-legacy  sample    6         2.000                  methods
HotScalacBenchmark.compile:·compiler.totalCompiles              ../corpus           latest                    false         2.12.10  async-legacy  sample    6     50450.000                  methods
HotScalacBenchmark.compile:·compiler.totalInvalidates           ../corpus           latest                    false         2.12.10  async-legacy  sample    6           ≈ 0                  methods
HotScalacBenchmark.compile:·compiler.totalTime                  ../corpus           latest                    false         2.12.10  async-legacy  sample    6    122522.387                       ms
HotScalacBenchmark.compile:·gc.alloc.rate                       ../corpus           latest                    false         2.12.10  async-legacy  sample    6       169.508 ±        7.103    MB/sec
HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus           latest                    false         2.12.10  async-legacy  sample    6  87433008.026 ±   149609.993      B/op
HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space              ../corpus           latest                    false         2.12.10  async-legacy  sample    6       175.200 ±      163.365    MB/sec
HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space.norm         ../corpus           latest                    false         2.12.10  async-legacy  sample    6  90361469.094 ± 83291753.373      B/op
HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space          ../corpus           latest                    false         2.12.10  async-legacy  sample    6         2.411 ±       10.329    MB/sec
HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space.norm     ../corpus           latest                    false         2.12.10  async-legacy  sample    6   1258719.547 ±  5408119.661      B/op
HotScalacBenchmark.compile:·gc.count                            ../corpus           latest                    false         2.12.10  async-legacy  sample    6        14.000                   counts
HotScalacBenchmark.compile:·gc.time                             ../corpus           latest                    false         2.12.10  async-legacy  sample    6       825.000                       ms
HotScalacBenchmark.compile:·rt.safepointSyncTime                ../corpus           latest                    false         2.12.10  async-legacy  sample    6       927.182                       ms
HotScalacBenchmark.compile:·rt.safepointTime                    ../corpus           latest                    false         2.12.10  async-legacy  sample    6      4249.463                       ms
HotScalacBenchmark.compile:·rt.safepoints                       ../corpus           latest                    false         2.12.10  async-legacy  sample    6     18349.000                   counts
HotScalacBenchmark.compile:·rt.sync.contendedLockAttempts       ../corpus           latest                    false         2.12.10  async-legacy  sample    6      5446.000                    locks
HotScalacBenchmark.compile:·rt.sync.fatMonitors                 ../corpus           latest                    false         2.12.10  async-legacy  sample    6       256.000                 monitors
HotScalacBenchmark.compile:·rt.sync.futileWakeups               ../corpus           latest                    false         2.12.10  async-legacy  sample    6      3394.000                   counts
HotScalacBenchmark.compile:·rt.sync.monitorDeflations           ../corpus           latest                    false         2.12.10  async-legacy  sample    6      1218.000                 monitors
HotScalacBenchmark.compile:·rt.sync.monitorInflations           ../corpus           latest                    false         2.12.10  async-legacy  sample    6      1220.000                 monitors
HotScalacBenchmark.compile:·rt.sync.notifications               ../corpus           latest                    false         2.12.10  async-legacy  sample    6        90.000                   counts
HotScalacBenchmark.compile:·rt.sync.parks                       ../corpus           latest                    false         2.12.10  async-legacy  sample    6      3871.000                   counts
HotScalacBenchmark.compile:·stack                               ../corpus           latest                    false         2.12.10  async-legacy  sample                NaN                      ---
HotScalacBenchmark.compile:·threads.cpu.time.norm               ../corpus           latest                    false         2.12.10  async-legacy  sample            443.695                    ms/op
HotScalacBenchmark.compile:·threads.user.time.norm              ../corpus           latest                    false         2.12.10  async-legacy  sample            429.893                    ms/op
```

```
Benchmark                                                    (corpusPath)  (corpusVersion)  (extraArgs)  (resident)                (scalaVersion)  (source)    Mode  Cnt         Score          Error     Units
HotScalacBenchmark.compile                                      ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample  354       171.165 ±        3.637     ms/op
HotScalacBenchmark.compile:compile·p0.00                        ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            144.703                    ms/op
HotScalacBenchmark.compile:compile·p0.50                        ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            166.199                    ms/op
HotScalacBenchmark.compile:compile·p0.90                        ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            201.458                    ms/op
HotScalacBenchmark.compile:compile·p0.95                        ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            217.711                    ms/op
HotScalacBenchmark.compile:compile·p0.99                        ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            235.065                    ms/op
HotScalacBenchmark.compile:compile·p0.999                       ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            251.920                    ms/op
HotScalacBenchmark.compile:compile·p0.9999                      ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            251.920                    ms/op
HotScalacBenchmark.compile:compile·p1.00                        ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            251.920                    ms/op
HotScalacBenchmark.compile:·compiler.nmethodCodeSize            ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6     73071.906                       Kb
HotScalacBenchmark.compile:·compiler.nmethodSize                ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6    146320.453                       Kb
HotScalacBenchmark.compile:·compiler.osrBytes                   ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6        37.067                       Kb
HotScalacBenchmark.compile:·compiler.osrCompiles                ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6        56.000                  methods
HotScalacBenchmark.compile:·compiler.osrTime                    ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       707.930                       ms
HotScalacBenchmark.compile:·compiler.standardBytes              ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6      7706.624                       Kb
HotScalacBenchmark.compile:·compiler.standardCompiles           ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6     28620.000                  methods
HotScalacBenchmark.compile:·compiler.standardTime               ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6    102229.056                       ms
HotScalacBenchmark.compile:·compiler.totalBailouts              ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6         3.000                  methods
HotScalacBenchmark.compile:·compiler.totalCompiles              ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6     28676.000                  methods
HotScalacBenchmark.compile:·compiler.totalInvalidates           ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6           ≈ 0                  methods
HotScalacBenchmark.compile:·compiler.totalTime                  ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6    102936.986                       ms
HotScalacBenchmark.compile:·gc.alloc.rate                       ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       310.930 ±       14.182    MB/sec
HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6  58648185.313 ±    38309.377      B/op
HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space              ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       297.827 ±      137.348    MB/sec
HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space.norm         ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6  56168723.665 ± 25638540.244      B/op
HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space          ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6         0.506 ±        1.071    MB/sec
HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space.norm     ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6     95240.352 ±   200428.077      B/op
HotScalacBenchmark.compile:·gc.count                            ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6        18.000                   counts
HotScalacBenchmark.compile:·gc.time                             ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       335.000                       ms
HotScalacBenchmark.compile:·rt.safepointSyncTime                ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       758.286                       ms
HotScalacBenchmark.compile:·rt.safepointTime                    ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6      3383.799                       ms
HotScalacBenchmark.compile:·rt.safepoints                       ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6     18279.000                   counts
HotScalacBenchmark.compile:·rt.sync.contendedLockAttempts       ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6      6422.000                    locks
HotScalacBenchmark.compile:·rt.sync.fatMonitors                 ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       128.000                 monitors
HotScalacBenchmark.compile:·rt.sync.futileWakeups               ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6      9166.000                   counts
HotScalacBenchmark.compile:·rt.sync.monitorDeflations           ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       256.000                 monitors
HotScalacBenchmark.compile:·rt.sync.monitorInflations           ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       258.000                 monitors
HotScalacBenchmark.compile:·rt.sync.notifications               ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6       117.000                   counts
HotScalacBenchmark.compile:·rt.sync.parks                       ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample    6      9937.000                   counts
HotScalacBenchmark.compile:·stack                               ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample                NaN                      ---
HotScalacBenchmark.compile:·threads.cpu.time.norm               ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            166.254                    ms/op
HotScalacBenchmark.compile:·threads.user.time.norm              ../corpus           latest                    false  2.12.11-bin-d053e66-SNAPSHOT     async  sample            156.229                    ms/op

Benchmark result is saved to /Users/jz/code/compiler-benchmark/target/profile-basic/result.json
```

